### PR TITLE
feat: 新增热点模块的跳转功能

### DIFF
--- a/BilibiliMonitor.js
+++ b/BilibiliMonitor.js
@@ -11,6 +11,7 @@ const $ = importModule("Env");
 var rid = 0; //rid对应不同的B站榜单：0全站，1动画，3音乐，4游戏，5娱乐，36科技，119鬼畜，129舞蹈。
 const title = `💗 B站榜单`;
 const preview = "medium";
+const goto = 'app'; // 可更改为 browser，跳转到浏览器，选择跳转 app 时若未安装 app，则会无响应
 const spacing = 5;
 
 try {
@@ -27,6 +28,17 @@ let widget = await createWidget(res);
 Script.setWidget(widget);
 Script.complete();
 
+function decideGoto(item) {
+  switch(goto) {
+    case 'app':
+      return item.uri;
+    case 'browser':
+      return `https://bilibili.com/${item.goto}${item.param}`;
+    default:
+      return void 0;
+  }
+}
+
 async function createWidget(res) {
   var group = res.data;
   items = [];
@@ -39,12 +51,12 @@ async function createWidget(res) {
   const opts = {
     title,
     texts: {
-      text1: `• ${items[0]}`,
-      text2: `• ${items[1]}`,
-      text3: `• ${items[2]}`,
-      text4: `• ${items[3]}`,
-      text5: `• ${items[4]}`,
-      text6: `• ${items[5]}`,
+      text1: { text: `• ${group[0].title}`, url: decideGoto(group[0]) },
+      text2: { text: `• ${group[1].title}`, url: decideGoto(group[1]) },
+      text3: { text: `• ${group[2].title}`, url: decideGoto(group[2]) },
+      text4: { text: `• ${group[3].title}`, url: decideGoto(group[3]) },
+      text5: { text: `• ${group[4].title}`, url: decideGoto(group[4]) },
+      text6: { text: `• ${group[5].title}`, url: decideGoto(group[5]) },
       battery: "true",
     },
     preview,

--- a/DoubanMonitor.js
+++ b/DoubanMonitor.js
@@ -11,12 +11,24 @@ const $ = importModule("Env");
 const title = `🎞 豆瓣电影`;
 const preview = "medium";
 const spacing = 5;
+const goto = 'app'; // 可更改为 browser，跳转到浏览器，选择跳转 app 时若未安装 app，则会无响应
 
 const res = await getinfo();
 
 let widget = await createWidget(res);
 Script.setWidget(widget);
 Script.complete();
+
+function decideGoto(item) {
+  switch(goto) {
+    case 'app':
+      return item.uri;
+    case 'browser':
+      return item.url;
+    default:
+      return void 0;
+  }
+}
 
 async function createWidget(res) {
   var group = res["subject_collection_items"];
@@ -37,12 +49,12 @@ async function createWidget(res) {
   const opts = {
     title,
     texts: {
-      text1: `• ${items[0]}`,
-      text2: `• ${items[1]}`,
-      text3: `• ${items[2]}`,
-      text4: `• ${items[3]}`,
-      text5: `• ${items[4]}`,
-      text6: `• ${items[5]}`,
+      text1: { text: `• ${items[0]}`, url: decideGoto(group[0]) },
+      text2: { text: `• ${items[1]}`, url: decideGoto(group[1]) },
+      text3: { text: `• ${items[2]}`, url: decideGoto(group[2]) },
+      text4: { text: `• ${items[3]}`, url: decideGoto(group[3]) },
+      text5: { text: `• ${items[4]}`, url: decideGoto(group[4]) },
+      text6: { text: `• ${items[5]}`, url: decideGoto(group[5]) },
       battery: "true",
     },
     preview,

--- a/WeiboMonitor.js
+++ b/WeiboMonitor.js
@@ -31,12 +31,12 @@ async function createWidget(res) {
     const opts = {
       title,
       texts: {
-        text1: `📌 ${items[0]}`,
-        text2: `• ${items[1]}`,
-        text3: `• ${items[2]}`,
-        text4: `• ${items[3]}`,
-        text5: `• ${items[4]}`,
-        text6: `• ${items[5]}`,
+        text1: { text: `📌 ${items[0]}`, url: group[0].scheme },
+        text2: { text: `• ${items[1]}`, url: group[1].scheme },
+        text3: { text: `• ${items[2]}`, url: group[2].scheme },
+        text4: { text: `• ${items[3]}`, url: group[3].scheme },
+        text5: { text: `• ${items[4]}`, url: group[4].scheme },
+        text6: { text: `• ${items[5]}`, url: group[5].scheme },
         battery: "true",
       },
       preview,

--- a/ZhihuMonitor.js
+++ b/ZhihuMonitor.js
@@ -11,12 +11,24 @@ const $ = importModule("Env");
 const title = `📖 知乎热榜`;
 const preview = "medium";
 const spacing = 5;
+const goto = 'app'; // 可更改为 browser，跳转到浏览器，选择跳转 app 时若未安装 app，则会无响应
 
 const res = await getinfo();
 
 let widget = await createWidget(res);
 Script.setWidget(widget);
 Script.complete();
+
+function decideGoto(item) {
+  switch(goto) {
+    case 'app':
+      return `zhihu://question/${item.target.id}`;
+    case 'browser':
+      return `https://m.zhihu.com/question/${item.target.id}`;
+    default:
+      return void 0;
+  }
+}
 
 async function createWidget(res) {
   if (res.fresh_text == "热榜已更新") {
@@ -31,12 +43,12 @@ async function createWidget(res) {
     const opts = {
       title,
       texts: {
-        text1: `• ${items[0]}`,
-        text2: `• ${items[1]}`,
-        text3: `• ${items[2]}`,
-        text4: `• ${items[3]}`,
-        text5: `• ${items[4]}`,
-        text6: `• ${items[5]}`,
+        text1: { text: `• ${items[0]}`, url: decideGoto(group[0]) },
+        text2: { text: `• ${items[1]}`, url: decideGoto(group[1]) },
+        text3: { text: `• ${items[2]}`, url: decideGoto(group[2]) },
+        text4: { text: `• ${items[3]}`, url: decideGoto(group[3]) },
+        text5: { text: `• ${items[4]}`, url: decideGoto(group[4]) },
+        text6: { text: `• ${items[5]}`, url: decideGoto(group[5]) },
         battery: "true",
       },
       preview,


### PR DESCRIPTION
⚠️⚠️⚠️ 此 PR 依赖刚提交的 Env 代码，不向下兼容，请谨慎合并。对于开启了自动更新的用户，会导致显示错误。

实现点击条目跳转到对应页面。

默认配置为 APP 跳转，但是如果没有安装 APP 的话会停留在 Scriptable 界面，跳转失败。可以将代码里的 `goto` 常量改为 `browser` 实现为跳转到 Safari 打开页面（微博除外，微博跳转的都是 HTTP 链接，所以不会失败）。

可解决 #7 